### PR TITLE
Use "large" size images on mobile devices

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WP Photo Sphere ===
+﻿=== WP Photo Sphere ===
 Contributors: Jeremy Heleine
 Tags: Google, Android, Photo Sphere, photos, panoramas, 360-degree, equirectangular
 Requires at least: 3.1
@@ -106,7 +106,7 @@ also use the `min_fov` and `max_fov` attributes.
 == Changelog ==
 
 = 3.5.2 =
-* Use WordPress 4.4+ medium-sized images on mobile devices
+* Use WordPress 4.4+ "large" images on mobile devices
 
 = 3.5.1 =
 * Portuguese translation updated

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Jeremy Heleine
 Tags: Google, Android, Photo Sphere, photos, panoramas, 360-degree, equirectangular
 Requires at least: 3.1
 Tested up to: 4.3
-Stable tag: 3.5.1
+Stable tag: 3.5.2
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 
@@ -104,6 +104,9 @@ also use the `min_fov` and `max_fov` attributes.
 3. Panorama
 
 == Changelog ==
+
+= 3.5.2 =
+* Use WordPress 4.4+ medium-sized images on mobile devices
 
 = 3.5.1 =
 * Portuguese translation updated

--- a/wp-photo-sphere.php
+++ b/wp-photo-sphere.php
@@ -28,7 +28,7 @@
 Plugin Name: WP Photo Sphere
 Plugin URI: http://jeremyheleine.me
 Description: A filter that displays 360×180 degree panoramas. Please read the readme file for instructions.
-Version: 3.5.1
+Version: 3.5.2
 Author: Jérémy Heleine
 Author URI: http://jeremyheleine.me
 Text Domain: wp-photo-sphere
@@ -38,7 +38,7 @@ License: MIT
 
 // Current version number
 if (!defined('WP_PHOTO_SPHERE_VERSION'))
-	define('WP_PHOTO_SPHERE_VERSION', '3.5.1');
+	define('WP_PHOTO_SPHERE_VERSION', '3.5.2');
 
 function wpps_activation() {
 	update_option('wpps_version', WP_PHOTO_SPHERE_VERSION);
@@ -211,7 +211,12 @@ function wpps_handle_shortcode($atts) {
 
 	if ($atts['id'] != 0) {
 		$id = $atts['id'];
-		$url = wp_get_attachment_url($id);
+		if  (floatval(get_bloginfo('version')) >= 4.4 && wp_is_mobile()) {
+			$url = wp_get_attachment_url($id, 'medium');
+		}
+		else {
+			$url = wp_get_attachment_url($id);
+		}
 		$text = str_replace('%title%', get_the_title($id), $title);
 	}
 

--- a/wp-photo-sphere.php
+++ b/wp-photo-sphere.php
@@ -3,7 +3,7 @@
  * WP Photo Sphere v3.5.1
  * http://jeremyheleine.me
  *
- * Copyright (c) 2013-2015 Jérémy Heleine
+ * Copyright (c) 2013-2015 Jéréfmy Heleine
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -212,7 +212,7 @@ function wpps_handle_shortcode($atts) {
 	if ($atts['id'] != 0) {
 		$id = $atts['id'];
 		if  (floatval(get_bloginfo('version')) >= 4.4 && wp_is_mobile()) {
-			$url = wp_get_attachment_url($id, 'medium');
+			$url = wp_get_attachment_url($id, 'large');
 		}
 		else {
 			$url = wp_get_attachment_url($id);


### PR DESCRIPTION
Use the new automatically scaled images in WordPress 4.4 to
load smaller versions of the photo spheres when a mobile device is
used. This prevents WebGL from running out of memory on the device, and
saves bandwidth.

Fixes bug described at
https://wordpress.org/support/topic/wont-load-on-mobile?replies=14